### PR TITLE
Change "Buenos Aires City" to the formal/real name

### DIFF
--- a/provinces.json
+++ b/provinces.json
@@ -748,7 +748,7 @@
 { "name": "Santiago de Cuba", "country": "CU" },
 { "name": "Santa Clara", "country": "CU" },
 
-{ "name": "Buenos Aires City", "country": "AR" },
+{ "name": "Ciudad Autónoma de Buenos Aires", "country": "AR" },
 { "name": "Buenos Aires", "country": "AR" },
 { "name": "Catamarca", "country": "AR" },
 { "name": "Chaco", "country": "AR" },


### PR DESCRIPTION
The difference is like "District of Columbia" vs "Columbia" vs "Columbia City" vs "Columbia State".
The formal name is "Ciudad Autónoma de Buenos Aires / C.A.B.A."