### PR TITLE
Remove Dutch territories

### DIFF
--- a/provinces.json
+++ b/provinces.json
@@ -304,12 +304,6 @@
 {"short":"UT","name":"Utrecht","country":"NL"},
 {"short":"ZH","name":"Zuid-Holland","country":"NL"},
 {"short":"ZL","name":"Zeeland","country":"NL"},
-{"short":"AW","name":"Aruba","country":"NL"},
-{"short":"BQ","name":"Bonaire","country":"NL"},
-{"short":"BQ2","name":"Saba","country":"NL"},
-{"short":"BQ3","name":"Sint Eustatius","country":"NL"},
-{"short":"CW","name":"Curaçao","country":"NL"},
-{"short":"SX","name":"Sint Maarten","country":"NL"},
 
 {"short":"ANT","name":"Antwerpen","country":"BE"},
 {"short":"HAI","name":"Henegouwen","country":"BE", "alt": ["Hainaut"]},


### PR DESCRIPTION
Curaçao, Sint Maarten and Aruba are countries within the Kingdom of The Netherlands. Bonaire, Saba and Sint Eustatius are not provinces but special municipalities of The Netherlands (the country).

My request is to release this as semver minor because it removes information instead of adding more information. Also, I am open to new insights to this topic because other people might want to keep these territories even though they are not provinces in the common sense of the word.

Fixes #31.